### PR TITLE
Fix Qwen3Moe GGUF loading

### DIFF
--- a/src/transformers/integrations/ggml.py
+++ b/src/transformers/integrations/ggml.py
@@ -102,13 +102,14 @@ GGUF_CONFIG_MAPPING = {
         "attention.layer_norm_rms_epsilon": "rms_norm_eps",
         "vocab_size": "vocab_size",
     },
-    "qwen3moe": {
+    "qwen3_moe": {
         "context_length": "max_position_embeddings",
         "block_count": "num_hidden_layers",
         "feed_forward_length": "intermediate_size",
         "embedding_length": "hidden_size",
         "rope.dimension_count": None,
         "rope.freq_base": "rope_theta",
+        "attention.key_length": "head_dim",
         "attention.head_count": "num_attention_heads",
         "attention.head_count_kv": "num_key_value_heads",
         "attention.layer_norm_rms_epsilon": "rms_norm_eps",


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

 I encountered the following error after trying out the latest commit in this branch to load a bf16 GGUF file of the Qwen3-30B-A3B model:
```
  File "/data_fast/home/jusjinuk/codes/transformers/src/transformers/modeling_gguf_pytorch_utils.py", line 121, in _split_moe_expert_tensor
    name = tensor_key_mapping[name]
KeyError: 'blk.24.ffn_down_exps.weight’
```

Upon investigation, I found that the issue arises because the code is not reading the config in [this code](https://github.com/ctcanbol/transformers/blob/344eaa3b90850bee89c2fb13bb0b16248bd0ce33/src/transformers/modeling_gguf_pytorch_utils.py#L436-L446). Thus, it uses the default `Qwen3MoeConfig` to instantiate the Qwen3Moe model in Transformers, which sets num_hidden_layers to 24 [by default](https://github.com/ctcanbol/transformers/blob/344eaa3b90850bee89c2fb13bb0b16248bd0ce33/src/transformers/models/qwen3_moe/configuration_qwen3_moe.py#L175). This does not match the actual number of layers in the GGUF files.

The reason for not loading the correct config is because the code reads `GGUF_CONFIG_MAPPING` with the architecture name updated [here](https://github.com/ctcanbol/transformers/blob/f43d297e569998121f5e3fad9b0ce271298574c1/src/transformers/modeling_gguf_pytorch_utils.py#L423), but `GGUF_CONFIG_MAPPING` has its keys with the [old architecture name](https://github.com/ctcanbol/transformers/blob/main/src/transformers/integrations/ggml.py#L105) (`qwen3moe`), thus is not correctly reading the necessary config.

To address this, I updated L105 to reflect the updated architecture name in the `GGUF_CONFIG_MAPPING` as shown in [this commit](https://github.com/jusjinuk/transformers/commit/f43d297e569998121f5e3fad9b0ce271298574c1). I believe qwen2moe should be updated similarly, but I left it unchanged since I have not personally tested the Qwen2Moe architecture. I also noticed a missing parameter (`head_dim`) and added it at L112 in the [same commit](https://github.com/jusjinuk/transformers/commit/f43d297e569998121f5e3fad9b0ce271298574c1).

---

After these changes, I confirmed that the output is generated without any issues, tested with the following code:
```python
from transformers import AutoModelForCausalLM, AutoTokenizer, TextStreamer
import torch

gguf_model_path = "gguf_files/Qwen_Qwen3-30B-A3B-Instruct-2507-bf16"
gguf_file_name = "qwen3-30b-a3b-instruct-2507-bf16.gguf"
tokenizer_name = "Qwen/Qwen3-30B-A3B-Instruct-2507"

model = AutoModelForCausalLM.from_pretrained(
    gguf_model_path, 
    gguf_file=gguf_file_name, 
    torch_dtype=torch.bfloat16, 
    device_map="auto",
)
tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
streamer = TextStreamer(tokenizer)

prompt = "Explain me what Large Language Models are."
chat = [
    {"role": "user", "content": prompt}
]
tokenized_chat = tokenizer.apply_chat_template(
    chat, tokenize=True, add_generation_prompt=True, return_tensors="pt")
tokenized_chat = tokenized_chat.to("cuda")
outputs = model.generate(tokenized_chat, max_new_tokens=100, streamer=streamer, eos_token_id=tokenizer.eos_token_id)
```

Thank you.


Fixes #39638


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface, @SunMarc and @qgallouedec
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
